### PR TITLE
fix: remove setup-python from gcp_deploy for RPi5 ARM64

### DIFF
--- a/.github/workflows/gcp_deploy.yml
+++ b/.github/workflows/gcp_deploy.yml
@@ -36,11 +36,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          cache: "pip"
-
       - name: Install dependencies
         run: pip install -r requirements.txt
 


### PR DESCRIPTION
RPi5 ARM64 Debian 12にsetup-python v5のバイナリがないため、システムPython 3.11.2を使用する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration by streamlining job setup steps while maintaining dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->