### PR TITLE
fix: use venv for gcp_deploy on RPi5

### DIFF
--- a/.github/workflows/gcp_deploy.yml
+++ b/.github/workflows/gcp_deploy.yml
@@ -36,8 +36,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: pip install -r requirements.txt
+      - name: Setup venv and install dependencies
+        run: |
+          python3 -m venv .venv
+          . .venv/bin/activate
+          pip install -r requirements.txt
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Setup GCP credentials
         run: echo '${{ secrets.GCP_SA_KEY }}' > /tmp/gcp-sa-key.json


### PR DESCRIPTION
externally-managed-environment対策