### PR TITLE
fix: use venv in weekly_retrain for RPi5 ARM64

### DIFF
--- a/.github/workflows/weekly_retrain.yml
+++ b/.github/workflows/weekly_retrain.yml
@@ -22,13 +22,12 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          cache: "pip"
-
-      - name: Install dependencies
-        run: pip install -r requirements.txt
+      - name: Setup venv and install dependencies
+        run: |
+          python3 -m venv .venv
+          . .venv/bin/activate
+          pip install -r requirements.txt
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Fetch Statcast data (incl. bat tracking + arsenal)
         run: python src/fetch_statcast.py


### PR DESCRIPTION
setup-python@v5のtoolcacheが壊れたため、システムPython+venvに切り替え